### PR TITLE
ci: add platformio build

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,3 +38,4 @@ jobs:
       run: pio ci --lib="." --board=teensy36
       env:
         PLATFORMIO_CI_SRC: ${{ matrix.example }}
+        PLATFORMIO_BUILD_FLAGS: -D USB_MIDI

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,40 @@
+name: PlatformIO CI
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        example: [edrumulus.ino]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Cache pip
+      uses: actions/cache@v2
+      with:
+        path: ~/.cache/pip
+        key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+        restore-keys: |
+          ${{ runner.os }}-pip-
+    - name: Cache PlatformIO
+      uses: actions/cache@v2
+      with:
+        path: ~/.platformio
+        key: ${{ runner.os }}-${{ hashFiles('**/lockfiles') }}
+
+    - name: Set up Python
+      uses: actions/setup-python@v2
+
+    - name: Install PlatformIO
+      run: |
+        python -m pip install --upgrade pip
+        pip install --upgrade platformio
+        
+    - name: Run PlatformIO
+      run: pio ci --lib="." --board=teensy36
+      env:
+        PLATFORMIO_CI_SRC: ${{ matrix.example }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,7 +35,7 @@ jobs:
         pip install --upgrade platformio
         
     - name: Run PlatformIO
-      run: pio ci --lib="." --board=esp-wrover-kit --board=teensy36 --board=teensy40
+      run: pio ci --lib="." --board=teensy36 --board=teensy40
       env:
         PLATFORMIO_CI_SRC: ${{ matrix.example }}
         PLATFORMIO_BUILD_FLAGS: -D USB_MIDI

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,7 +35,7 @@ jobs:
         pip install --upgrade platformio
         
     - name: Run PlatformIO
-      run: pio ci --lib="." --board=teensy36
+      run: pio ci --lib="." --board=teensy36 --board=teensy40
       env:
         PLATFORMIO_CI_SRC: ${{ matrix.example }}
         PLATFORMIO_BUILD_FLAGS: -D USB_MIDI

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,7 +35,7 @@ jobs:
         pip install --upgrade platformio
         
     - name: Run PlatformIO
-      run: pio ci --lib="." --board=teensy36 --board=teensy40
+      run: pio ci --lib="." --board=esp-wrover-kit --board=teensy36 --board=teensy40
       env:
         PLATFORMIO_CI_SRC: ${{ matrix.example }}
         PLATFORMIO_BUILD_FLAGS: -D USB_MIDI


### PR DESCRIPTION
this uses github actions and platformio to build the code against one or more boards. Testing against Teensy 3.6 for now but other boards can be added easily.

More info on https://docs.platformio.org/en/latest/integration/ci/github-actions.html