### PR TITLE
SDCARD_OUT: compile switch to write edrumulus signals to a SD card

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -26,6 +26,11 @@ platform = teensy
 board = teensy36
 build_flags = -D USB_MIDI_SERIAL
 
+[env:teensy36sdcard]
+platform = teensy
+board = teensy36
+build_flags = -D USB_MIDI_SERIAL -D SDCARD_OUT
+
 [env:teensy40]
 platform = teensy
 board = teensy40
@@ -35,6 +40,11 @@ build_flags = -D USB_MIDI_SERIAL
 platform = teensy
 board = teensy41
 build_flags = -D USB_MIDI_SERIAL
+
+[env:teensy41sdcard]
+platform = teensy
+board = teensy41
+build_flags = -D USB_MIDI_SERIAL -D SDCARD_OUT
 
 ; see https://docs.platformio.org/en/latest/platforms/espressif32.html for more details
 [env:esp32doit-devkit-v1]

--- a/platformio.ini
+++ b/platformio.ini
@@ -24,17 +24,17 @@ build_src_filter =
 [env:teensy36]
 platform = teensy
 board = teensy36
-build_flags = -D USB_MIDI
+build_flags = -D USB_MIDI_SERIAL
 
 [env:teensy40]
 platform = teensy
 board = teensy40
-build_flags = -D USB_MIDI
+build_flags = -D USB_MIDI_SERIAL
 
 [env:teensy41]
 platform = teensy
 board = teensy41
-build_flags = -D USB_MIDI
+build_flags = -D USB_MIDI_SERIAL
 
 ; see https://docs.platformio.org/en/latest/platforms/espressif32.html for more details
 [env:esp32doit-devkit-v1]


### PR DESCRIPTION
Signals are written to the SD card at a dedicated edrumulus directory.
Files are rotated every minute to avoid data loss due to a power cycle.

The output format is 16 Bit PCM wav, which is 4 Bits more than the
format edrumulus uses (i.e. 20-30dB more than the maximum amplitude).

This is mostly meant to help with debugging edrumulus to e.g. support
new pads. It tends to be more realistic than the current test method,
which involves using the sound card (incl. clipping, better ADCs etc.).

The performance impact during regular drumming should be negligible as
long as no SD card is inserted at boot time.

Obviously the board needs to have a SD card slot, which is currently
only true for certain Teensy models.