### PR TITLE
Revert "platformio config: use arduino-esp32 2.0.9"

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -39,15 +39,12 @@ build_flags = -D USB_MIDI_SERIAL
 ; see https://docs.platformio.org/en/latest/platforms/espressif32.html for more details
 [env:esp32doit-devkit-v1]
 platform = espressif32
-platform_packages = framework-arduinoespressif32 @ https://github.com/espressif/arduino-esp32.git#2.0.9
 board = esp32doit-devkit-v1
 
 [env:az-delivery-devkit-v4]
 platform = espressif32
-platform_packages = framework-arduinoespressif32 @ https://github.com/espressif/arduino-esp32.git#2.0.9
 board = az-delivery-devkit-v4
 
 [env:esp32-s3-devkitc-1]
 platform = espressif32
-platform_packages = framework-arduinoespressif32 @ https://github.com/espressif/arduino-esp32.git#2.0.9
 board = esp32-s3-devkitc-1


### PR DESCRIPTION
This reverts commit 8581fd7ca237542e5d4e3e3d0dcd18b65f945451.

Versions >= 2.0.12 don't have the MIDI bug anymore.

https://github.com/corrados/edrumulus/discussions/101