### PR TITLE
safety check

### DIFF
--- a/edrumulus.cpp
+++ b/edrumulus.cpp
@@ -106,6 +106,36 @@ void Edrumulus::setup ( const int  conf_num_pads,
       }
     }
   }
+
+  #ifndef UNSAFE
+    // safety check: make sure the DC offset is in expected ranges
+    // (i.e. around 1.65V for the voltage divider circuits)
+    bool safety_check_passed = true;
+    int offset;
+    for ( int i = 0; i < number_pads; i++ )
+    {
+      if (i == 3) continue; //Hihat Control (NOTE: the pad may not yet be configured as control, i.e. we cannot use the pad settings here)
+
+      for ( int j = 0; j < number_inputs[i]; j++ )
+      {
+        offset = dc_offset[i][j];
+          if (( offset > dc_offset_max ) || ( offset < dc_offset_min ))
+          {
+            safety_check_passed = false;
+            Serial.print("Safety check: Bad DC offset ");
+            Serial.print(offset);
+            Serial.print(" on pin ");
+            Serial.println(analog_pin[i][j]);
+          }
+      }
+    }
+
+    if (!safety_check_passed)
+    {
+      Serial.println("Safety checks didn't pass. Maybe your circuit is bad?");
+      edrumulus_hardware.abort();
+    }
+  #endif
 }
 
 

--- a/edrumulus.h
+++ b/edrumulus.h
@@ -530,6 +530,8 @@ const float ADC_noise_peak_velocity_scaling = 1.0f / 6.0f;
 
   // constant definitions
   const int dc_offset_est_len       = 10000; // samples (about a second at 8 kHz sampling rate)
+  const int dc_offset_min           = 1200; // minimum allowed DC offset (should be around 1.65V = 2^11)
+  const int dc_offset_max           = 2300; // maximum allowed DC offset (should be around 1.65V = 2^11)
   const int samplerate_max_cnt      = 10000; // samples
   const int samplerate_max_error_Hz = 100;   // tolerate a sample rate deviation of 100 Hz
   const int cancel_time_ms          = 30;    // on same stand approx. 10 ms + some margin (20 ms)

--- a/edrumulus_hardware.cpp
+++ b/edrumulus_hardware.cpp
@@ -120,6 +120,17 @@ byte Edrumulus_hardware::read_setting ( const int pad_index,
 }
 
 
+void Edrumulus_hardware::abort ()
+{
+  Serial.println("Aborting...");
+  while (true)
+  {
+    digitalWriteFast(LED_BUILTIN, !digitalReadFast(LED_BUILTIN));
+    delay(50);
+  }
+}
+
+
 void Edrumulus_hardware::on_timer()
 {
   // tell the main loop that a sample can be read by setting the flag (semaphore)
@@ -379,6 +390,16 @@ void IRAM_ATTR Edrumulus_hardware::on_timer()
   if ( xHigherPriorityTaskWoken == pdTRUE )
   {
     portYIELD_FROM_ISR();
+  }
+}
+
+
+void Edrumulus_hardware::abort ()
+{
+  Serial.println("Aborting...");
+  while (true)
+  {
+    delay(100000);
   }
 }
 

--- a/edrumulus_hardware.h
+++ b/edrumulus_hardware.h
@@ -75,6 +75,7 @@ public:
 
   void write_setting ( const int pad_index, const int address, const byte value );
   byte read_setting  ( const int pad_index, const int address );
+  void abort ();
 
 protected:
   int           Fs;
@@ -150,6 +151,7 @@ public:
 
   void write_setting ( const int, const int, const byte ) {}; // not supported
   byte read_setting  ( const int, const int ) { return 0; };  // not supported
+  void abort ();
 
 protected:
   int                        Fs;


### PR DESCRIPTION
Check on edrumulus startup, if the ADCs roughly detect the expected 1,65V from the voltage divider circuits. If not, abort and inform the user via serial console about the issue.

The control port is skipped.

This check may may detect:
- incorrect analog circuits
- broken microcontroller ADCs
- pads drawing current
- accidental shorts