### PR TITLE
build: test against upcoming arduino-esp32 3.0

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -48,3 +48,11 @@ board = az-delivery-devkit-v4
 [env:esp32-s3-devkitc-1]
 platform = espressif32
 board = esp32-s3-devkitc-1
+
+; see https://docs.espressif.com/projects/arduino-esp32/en/latest/installing.html#how-to-update-to-the-latest-code
+[env:arduino-latest]
+platform = https://github.com/platformio/platform-espressif32.git
+board = az-delivery-devkit-v4
+framework = arduino
+platform_packages =
+    framework-arduinoespressif32 @ https://github.com/espressif/arduino-esp32#master


### PR DESCRIPTION
Test against upcoming arduino-esp32 3.0, see https://blog.espressif.com/announcing-the-arduino-esp32-core-version-3-0-0-3bf9f24e20d4

There's also a migration guide for 2.x to 3.x: https://docs.espressif.com/projects/arduino-esp32/en/latest/migration_guides/2.x_to_3.0.html