### PR TITLE
choke: always send all MIDI notes of an instrument

### DIFF
--- a/edrumulus.ino
+++ b/edrumulus.ino
@@ -227,12 +227,8 @@ void loop()
         // if grabbed edge found, polyphonic aftertouch at 127 is transmitted for all notes of the pad
         MYMIDI.MIDI_SEND_AFTER_TOUCH ( edrumulus.get_midi_note_norm ( pad_idx ), 127, midi_channel );
         MYMIDI.MIDI_SEND_AFTER_TOUCH ( edrumulus.get_midi_note_rim  ( pad_idx ), 127, midi_channel );
-
-        if ( pad_idx == hihat_pad_idx )
-        {
-          MYMIDI.MIDI_SEND_AFTER_TOUCH ( edrumulus.get_midi_note_open_norm ( pad_idx ), 127, midi_channel );
-          MYMIDI.MIDI_SEND_AFTER_TOUCH ( edrumulus.get_midi_note_open_rim  ( pad_idx ), 127, midi_channel );
-        }
+        MYMIDI.MIDI_SEND_AFTER_TOUCH ( edrumulus.get_midi_note_open_norm ( pad_idx ), 127, midi_channel );
+        MYMIDI.MIDI_SEND_AFTER_TOUCH ( edrumulus.get_midi_note_open_rim  ( pad_idx ), 127, midi_channel );
       }
     }
     else if ( edrumulus.get_choke_off_found ( pad_idx ) )
@@ -240,12 +236,8 @@ void loop()
       // if released edge found, polyphonic aftertouch at 0 is transmitted for all notes of the pad
       MYMIDI.MIDI_SEND_AFTER_TOUCH ( edrumulus.get_midi_note_norm ( pad_idx ), 0, midi_channel );
       MYMIDI.MIDI_SEND_AFTER_TOUCH ( edrumulus.get_midi_note_rim  ( pad_idx ), 0, midi_channel );
-
-      if ( pad_idx == hihat_pad_idx )
-      {
-        MYMIDI.MIDI_SEND_AFTER_TOUCH ( edrumulus.get_midi_note_open_norm ( pad_idx ), 0, midi_channel );
-        MYMIDI.MIDI_SEND_AFTER_TOUCH ( edrumulus.get_midi_note_open_rim  ( pad_idx ), 0, midi_channel );
-      }
+      MYMIDI.MIDI_SEND_AFTER_TOUCH ( edrumulus.get_midi_note_open_norm ( pad_idx ), 0, midi_channel );
+      MYMIDI.MIDI_SEND_AFTER_TOUCH ( edrumulus.get_midi_note_open_rim  ( pad_idx ), 0, midi_channel );
     }
   }
 


### PR DESCRIPTION
This is required for e.g. 3-zone cymbals such as the one of the MPS750x.