### PR TITLE
EEPROM -> Preferences for ESP32

### DIFF
--- a/edrumulus.ino
+++ b/edrumulus.ino
@@ -35,7 +35,7 @@ const int number_pads4 = 8; // example: do not use tom3 and shrink number of pad
 #ifdef USE_MIDI
 # ifdef ESP_PLATFORM
 #  include <MIDI.h>
-MIDI_CREATE_DEFAULT_INSTANCE();
+     MIDI_CREATE_DEFAULT_INSTANCE();
 #  define MYMIDI                     MIDI
 #  define MIDI_CONTROL_CHANGE_TYPE   midi::ControlChange
 #  define MIDI_SEND_AFTER_TOUCH      sendAfterTouch
@@ -64,9 +64,9 @@ void setup()
   int* analog_pins         = analog_pins4;         // initialize with the default setup
   int* analog_pins_rimshot = analog_pins_rimshot4; // initialize with the default setup
   const int prototype = Edrumulus_hardware::get_prototype_pins ( &analog_pins,
-                                                                 &analog_pins_rimshot,
-                                                                 &number_pads,
-                                                                 &status_LED_pin );
+   &analog_pins_rimshot,
+   &number_pads,
+   &status_LED_pin );
 
   // initialize GPIO port for status LED and set it to on during setup
   pinMode ( status_LED_pin, OUTPUT );
@@ -93,11 +93,7 @@ void setup()
 
   edrumulus.setup ( number_pads, analog_pins, analog_pins_rimshot );
   digitalWrite ( status_LED_pin, LOW ); // set board LED to low right after setup is done
-#ifdef ESP_PLATFORM
-  preset_settings(); // for ESP32, the load/save of settings is not supported, preset instead
-#else
   read_settings();
-#endif
 }
 
 

--- a/edrumulus_hardware.cpp
+++ b/edrumulus_hardware.cpp
@@ -159,14 +159,14 @@ void Edrumulus_hardware::write_setting ( const int  pad_index,
                                          const byte value )
 {
   const char* key = String(pad_index * MAX_NUM_SET_PER_PAD + address).c_str();
-  preferences_settings.putUChar( key, value );
+  settings.putUChar( key, value );
 }
 
 byte Edrumulus_hardware::read_setting ( const int pad_index,
                                         const int address )
 {
   const char* key = String(pad_index * MAX_NUM_SET_PER_PAD + address).c_str();
-  return preferences_settings.getUChar( key, 0 );
+  return settings.getUChar( key, 0 );
 }
 
 int Edrumulus_hardware::get_prototype_pins ( int** analog_pins,
@@ -241,7 +241,7 @@ void Edrumulus_hardware::setup ( const int conf_Fs,
 {
   // set essential parameters
   Fs = conf_Fs;
-  preferences_settings.begin ( "Settings", false); 
+  settings.begin ( "Settings", false); 
   // create linear vectors containing the pin/ADC information for each pad and pad-input
   bool input_is_used[MAX_NUM_PADS * MAX_NUM_PAD_INPUTS];
   int  input_adc[MAX_NUM_PADS * MAX_NUM_PAD_INPUTS];

--- a/edrumulus_hardware.cpp
+++ b/edrumulus_hardware.cpp
@@ -241,7 +241,8 @@ void Edrumulus_hardware::setup ( const int conf_Fs,
 {
   // set essential parameters
   Fs = conf_Fs;
-  settings.begin ( "Settings", false); 
+  char preferences_namespace[16] = "Edrumulus";
+  settings.begin (preferences_namespace, false); 
   // create linear vectors containing the pin/ADC information for each pad and pad-input
   bool input_is_used[MAX_NUM_PADS * MAX_NUM_PAD_INPUTS];
   int  input_adc[MAX_NUM_PADS * MAX_NUM_PAD_INPUTS];

--- a/edrumulus_hardware.cpp
+++ b/edrumulus_hardware.cpp
@@ -154,6 +154,21 @@ void Edrumulus_hardware::capture_samples ( const int number_pads,
 // -----------------------------------------------------------------------------
 #ifdef ESP_PLATFORM
 
+void Edrumulus_hardware::write_setting ( const int  pad_index,
+                                         const int  address,
+                                         const byte value )
+{
+  const char* key = String(pad_index * MAX_NUM_SET_PER_PAD + address).c_str();
+  preferences_settings.putUChar( key, value );
+}
+
+byte Edrumulus_hardware::read_setting ( const int pad_index,
+                                        const int address )
+{
+  const char* key = String(pad_index * MAX_NUM_SET_PER_PAD + address).c_str();
+  return preferences_settings.getUChar( key, 0 );
+}
+
 int Edrumulus_hardware::get_prototype_pins ( int** analog_pins,
                                              int** analog_pins_rimshot,
                                              int*  number_pins,
@@ -207,7 +222,7 @@ int Edrumulus_hardware::get_prototype_pins ( int** analog_pins,
   *status_LED_pin = BOARD_LED_PIN;
   return 4;
 #else // CONFIG_IDF_TARGET_ESP32S3
-  // analog pins setup:                 snare | kick | hi-hat | hi-hat-ctrl | crash | tom1 | ride | tom2 | tom3  
+// analog pins setup:                 snare | kick | hi-hat | hi-hat-ctrl | crash | tom1 | ride | tom2 | tom3  
   static int analog_pins_s3[]         = {  4,     6,      7,        9,         10,     12,    13,    15,    16 };
   static int analog_pins_rimshot_s3[] = {  5,    -1,      8,       -1,         11,     -1,    14,    -1,    -1 };
   *analog_pins         = analog_pins_s3;
@@ -226,8 +241,7 @@ void Edrumulus_hardware::setup ( const int conf_Fs,
 {
   // set essential parameters
   Fs = conf_Fs;
-  eeprom_settings.begin ( ( number_pads + 1 ) * MAX_NUM_SET_PER_PAD ); // "+ 1" for pad-independent global settings
-
+  preferences_settings.begin ( "Settings", false); 
   // create linear vectors containing the pin/ADC information for each pad and pad-input
   bool input_is_used[MAX_NUM_PADS * MAX_NUM_PAD_INPUTS];
   int  input_adc[MAX_NUM_PADS * MAX_NUM_PAD_INPUTS];

--- a/edrumulus_hardware.h
+++ b/edrumulus_hardware.h
@@ -18,8 +18,6 @@
 #pragma once
 
 #include "Arduino.h"
-#include "EEPROM.h"
-
 
 // Global hardware enums and definitions ---------------------------------------
 enum Espikestate
@@ -41,6 +39,7 @@ enum Espikestate
 // -----------------------------------------------------------------------------
 #ifdef TEENSYDUINO
 
+#include "EEPROM.h"
 #include <ADC.h>
 
 #define BOARD_LED_PIN        13    // pin number of the LED on the Teensy 4.0 board
@@ -110,6 +109,7 @@ protected:
 // -----------------------------------------------------------------------------
 #ifdef ESP_PLATFORM
 
+#include <Preferences.h>
 #include "soc/sens_reg.h"
 #include "driver/adc.h"
 #ifdef CONFIG_IDF_TARGET_ESP32
@@ -148,12 +148,12 @@ public:
                            const int input_channel_index,
                            const int level );
 
-  void write_setting ( const int, const int, const byte ) {}; // not supported
-  byte read_setting  ( const int, const int ) { return 0; };  // not supported
+  void write_setting ( const int pad_index, const int address, const byte value );
+  byte read_setting  ( const int pad_index, const int address );
 
 protected:
   int                        Fs;
-  EEPROMClass                eeprom_settings;
+  Preferences                preferences_settings;
   volatile SemaphoreHandle_t timer_semaphore;
   hw_timer_t*                timer = nullptr;
   static void IRAM_ATTR      on_timer();

--- a/edrumulus_hardware.h
+++ b/edrumulus_hardware.h
@@ -153,7 +153,7 @@ public:
 
 protected:
   int                        Fs;
-  Preferences                preferences_settings;
+  Preferences                settings;
   volatile SemaphoreHandle_t timer_semaphore;
   hw_timer_t*                timer = nullptr;
   static void IRAM_ATTR      on_timer();


### PR DESCRIPTION
For ESP32 : implement [Preferences](https://espressif-docs.readthedocs-hosted.com/projects/arduino-esp32/en/latest/api/preferences.html) for settings storage as it "should be considered as the replacement for the Arduino EEPROM library".