### PR TITLE
Hihat pedal: only trigger when it's absolutely closed

### DIFF
--- a/pad.h
+++ b/pad.h
@@ -207,7 +207,7 @@ class Pad
 
   // definitions which can be used outside the pad class, too
   static const int control_midi_hysteresis       = ADC_MAX_NOISE_AMPL / 2; // MIDI hysteresis for the controller to suppress noise
-  static const int hi_hat_is_open_MIDI_threshold = 100;                    // MIDI values smaller than the limit value are "open hi-hat"
+  static const int hi_hat_is_open_MIDI_threshold = 122;                    // MIDI values smaller than the limit value are "open hi-hat"
 
  protected:
   struct Epadsettings

--- a/tools/create_drumgizmo_kit.py
+++ b/tools/create_drumgizmo_kit.py
@@ -48,14 +48,14 @@ channel_names   = ["KDrum", "Snare", "Hihat", "Tom1", "Tom2", "Tom3", "OHLeft", 
 instruments = [["kick",            ["KDrum", "OHLeft", "OHRight"], [36],     "",      "",   0.1,  15], \
                ["snare",           ["Snare", "OHLeft", "OHRight"], [38],     "",      "",   0.08, 16], \
                ["snare_rimshot",   ["Snare", "OHLeft", "OHRight"], [40],     "",      "",   0.3,  15], \
-               ["hihat_closed",    ["Hihat", "OHLeft", "OHRight"], [22, 26], "hihat", "80", 0.18, 20], \
-               ["hihat_closedtop", ["Hihat", "OHLeft", "OHRight"], [42, 46], "hihat", "80", 0.2,  20], \
+               ["hihat_closed",    ["Hihat", "OHLeft", "OHRight"], [22, 26], "hihat", "122",0.18, 20], \
+               ["hihat_closedtop", ["Hihat", "OHLeft", "OHRight"], [42, 46], "hihat", "122",0.2,  20], \
                ["hihat_open",      ["Hihat", "OHLeft", "OHRight"], [26],     "hihat", "0",  0.7,  23], \
-               ["hihat_open1",     ["Hihat", "OHLeft", "OHRight"], [26],     "hihat", "55", 0.7,  23], \
-               ["hihat_open2",     ["Hihat", "OHLeft", "OHRight"], [26],     "hihat", "27", 0.7,  23], \
+               ["hihat_open1",     ["Hihat", "OHLeft", "OHRight"], [26],     "hihat", "80", 0.7,  23], \
+               ["hihat_open2",     ["Hihat", "OHLeft", "OHRight"], [26],     "hihat", "30", 0.7,  23], \
                ["hihat_opentop",   ["Hihat", "OHLeft", "OHRight"], [46],     "hihat", "0",  0.7,  24], \
-               ["hihat_open1top",  ["Hihat", "OHLeft", "OHRight"], [46],     "hihat", "55", 0.7,  21], \
-               ["hihat_open2top",  ["Hihat", "OHLeft", "OHRight"], [46],     "hihat", "27", 0.7,  23], \
+               ["hihat_open1top",  ["Hihat", "OHLeft", "OHRight"], [46],     "hihat", "80", 0.7,  21], \
+               ["hihat_open2top",  ["Hihat", "OHLeft", "OHRight"], [46],     "hihat", "30", 0.7,  23], \
                ["hihat_foot",      ["Hihat", "OHLeft", "OHRight"], [44],     "hihat", "",   0.1,  23], \
                ["tom1",            ["Tom1", "OHLeft", "OHRight"],  [48, 50], "",      "",   0.2,  15], \
                ["tom2",            ["Tom2", "OHLeft", "OHRight"],  [45, 47], "",      "",   0.2,  15], \


### PR DESCRIPTION
This makes pedal stomps caused by half-open hihat play less likely.

Also increase the various hihat ranges so that they can be used more easily.

Fixes #145